### PR TITLE
Add standalone test page for react-chart-editor bundle

### DIFF
--- a/dockerfiles/react-chart-editor/Dockerfile
+++ b/dockerfiles/react-chart-editor/Dockerfile
@@ -130,7 +130,8 @@ RUN set -eu; \
     '  const { useState, useEffect } = React;' \
     '' \
     '  function App(){' \
-    '    const [figure, setFigure] = useState({ data: [], layout: {} });' \
+    '    const initial = globalThis.GENAPP_INITIAL_FIGURE || { data: [], layout: {} };' \
+    '    const [figure, setFigure] = useState(initial);' \
     '' \
     '    useEffect(() => {' \
     '      const handleMessage = (e) => {' \

--- a/dockerfiles/react-chart-editor/_chart_edit.html
+++ b/dockerfiles/react-chart-editor/_chart_edit.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Chart editor</title>
+<link rel="stylesheet" href="react-chart-editor.min.css">
+<style>
+  html, body { margin: 0; height: 100%; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  #editor-root { height: 100%; }
+</style>
+</head>
+<body>
+<div id="editor-root"></div>
+
+<script>
+  // Standalone test data. When opened by a GenApp page, this is replaced by
+  // a postMessage({type: "LOAD_CHART", payload: figure}) from the opener,
+  // so this default is only used when the page is opened directly.
+  window.GENAPP_INITIAL_FIGURE = {
+    data: [
+      {
+        type: "scatter",
+        mode: "lines+markers",
+        x: [1, 2, 3, 4, 5],
+        y: [2, 5, 3, 8, 4],
+        name: "Sample series"
+      }
+    ],
+    layout: {
+      title: "Sample chart (standalone test data)"
+    }
+  };
+</script>
+<script src="react-chart-editor.bundle.min.js"></script>
+<script src="react-chart-editor.app.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `_chart_edit.html`, a standalone test page that loads the bundled react-chart-editor (css + bundle + app helper) with sample data so it can be tested without GenApp.
- App entry now seeds the editor from `window.GENAPP_INITIAL_FIGURE` if set, falling back to the existing empty figure (used by the real postMessage `LOAD_CHART` flow).

## Test plan
- [x] `docker build -t rce-bundle -f Dockerfile .`
- [x] `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD/out:/out" rce-bundle`
- [x] Copy `_chart_edit.html` into `out/`, serve statically, open in browser — editor mounts, sample chart renders, controls sidebar present, no console errors