### PR TITLE
Fix empty editor controls panel in react-chart-editor bundle

### DIFF
--- a/dockerfiles/react-chart-editor/Dockerfile
+++ b/dockerfiles/react-chart-editor/Dockerfile
@@ -155,7 +155,7 @@ RUN set -eu; \
     '          useDefaultConfig: true,' \
     '          onUpdate: (data, layout) => setFigure({ data, layout }),' \
     '        },' \
-    '        (editorProps) => React.createElement(DefaultEditor, editorProps)' \
+    '        React.createElement(DefaultEditor)' \
     '      )' \
     '    );' \
     '  }' \


### PR DESCRIPTION
## Summary
- `EditorControls` only renders its children once `graphDiv._fullLayout` is set (handled internally by `PlotlyEditor`), and expects `children` to be a plain React element — falling back to `<DefaultEditor/>` if none is given. It does **not** call children as a render-prop function.
- The bundled `app-entry.js` was passing `(editorProps) => React.createElement(DefaultEditor, editorProps)`, a function. React silently drops invalid function children in production builds (the dev warning is stripped), so `.editor_controls` rendered with 0 children and no console error.
- Fix: pass `React.createElement(DefaultEditor)` directly.

## Test plan
- [x] `docker build -t rce-bundle -f Dockerfile .`
- [x] `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD/out:/out" rce-bundle`
- [x] Copy `_chart_edit.html` into `out/`, serve statically, open in browser — full editor now renders: Structure/Style/Annotate tabs, Traces panel showing "Sample series" (type Line), +Trace button, plot unchanged