### PR TITLE
Add noopener to Edit in Chart Editor window.open

### DIFF
--- a/languages/html5/js/data.js
+++ b/languages/html5/js/data.js
@@ -174,7 +174,8 @@ ga.data.update = function( mod, data, msging_f, msg_id ) {
                                     localStorage.setItem( id, JSON.stringify( { data: gd.data, layout: gd.layout } ) );
                                     window.open(
                                         v.config.genapp_chart_editor.url + '?id=' + encodeURIComponent( id ),
-                                        v.config.genapp_chart_editor.target || '_blank'
+                                        v.config.genapp_chart_editor.target || '_blank',
+                                        'noopener'
                                     );
                                 }
                             }]);


### PR DESCRIPTION
Defense-in-depth: prevents the opened _chart_edit.html tab from retaining a window.opener reference (reverse-tabnabbing). Low risk since the URL is a fixed same-origin path set server-side, but cheap to add.