### PR TITLE
Add ga.data.plotly namespace with modeBar buttons for errorbars and linewidth

### DIFF
--- a/languages/html5/js/data.js
+++ b/languages/html5/js/data.js
@@ -181,6 +181,42 @@ ga.data.update = function( mod, data, msging_f, msg_id ) {
                                 }
                             }]);
                         }
+                        if ( v.config.genapp_plotly ) {
+                            ga.data.plotly._config[ k ] = v.config.genapp_plotly;
+                            var _gp = v.config.genapp_plotly;
+                            v.config.modeBarButtonsToAdd = ( v.config.modeBarButtonsToAdd || [] );
+
+                            if ( _gp.errorbars ) {
+                                v.config.modeBarButtonsToAdd.push({
+                                    name  : 'toggleErrorbars',
+                                    title : 'Toggle error bars',
+                                    icon  : ga.data.plotly._ebIcon,
+                                    click : (function( divId ) {
+                                        var _visible = true;
+                                        return function() {
+                                            _visible = !_visible;
+                                            ga.data.plotly.errorbars( divId, _visible );
+                                        };
+                                    })( k )
+                                });
+                            }
+
+                            if ( _gp.linewidth ) {
+                                var _lwVals = _gp.linewidth.values || [1, 2, 3];
+                                v.config.modeBarButtonsToAdd.push({
+                                    name  : 'cycleLinewidth',
+                                    title : 'Cycle line width',
+                                    icon  : ga.data.plotly._lwIcon,
+                                    click : (function( divId, vals ) {
+                                        var _idx = 0;
+                                        return function() {
+                                            _idx = ( _idx + 1 ) % vals.length;
+                                            ga.data.plotly.linewidth( divId, vals[ _idx ] );
+                                        };
+                                    })( k, _lwVals )
+                                });
+                            }
+                        }
 		        Plotly.newPlot(k, v.data, v.layout, v.config);
                     } else {
 		        Plotly.newPlot(k, v.data, v.layout );
@@ -708,32 +744,47 @@ ga.data.iframe = function( v ) {
 }
 
 ga.data.plotly = {};
-ga.data.plotly.errorbars = function( divId, turnoff ) {
-    const gd = document.getElementById( divId );
-    if ( !gd || !gd.data ) {
-        console.warn( `no plotly data for ${divId}` );
-        return;
-    }
+ga.data.plotly._config = {};
 
-    Plotly.restyle( divId, { 'error_y.visible':turnoff }, [...Array(gd.data.length - 1).keys()].slice(1) );
-}
+ga.data.plotly._ebIcon = {
+    width: 500, height: 500,
+    path: 'M150,0 H350 V30 H150 Z ' +
+          'M240,30 H260 V210 H240 Z ' +
+          'M210,250 A40,40 0 1,0 290,250 A40,40 0 1,0 210,250 Z ' +
+          'M240,290 H260 V470 H240 Z ' +
+          'M150,470 H350 V500 H150 Z'
+};
+
+ga.data.plotly._lwIcon = {
+    width: 500, height: 500,
+    path: 'M0,90 H500 V110 H0 Z ' +
+          'M0,230 H500 V270 H0 Z ' +
+          'M0,365 H500 V435 H0 Z'
+};
+
+ga.data.plotly._indices = function( divId, feature, defaultSlice ) {
+    var cfg = ga.data.plotly._config[ divId ];
+    var spec = ( cfg && cfg[ feature ] && cfg[ feature ].traces !== undefined )
+               ? cfg[ feature ].traces : defaultSlice;
+    return [ ...Array( document.getElementById( divId ).data.length ).keys() ].slice( ...spec );
+};
+
+ga.data.plotly.errorbars = function( divId, visible ) {
+    var gd = document.getElementById( divId );
+    if ( !gd || !gd.data ) { console.warn( `no plotly data for ${divId}` ); return; }
+    Plotly.restyle( divId, { 'error_y.visible': visible },
+                    ga.data.plotly._indices( divId, 'errorbars', [1, -1] ) );
+};
 
 ga.data.plotly.linewidth = function( divId, linewidth ) {
-    const gd = document.getElementById( divId );
-    if ( !gd || !gd.data ) {
-        console.warn( `no plotly data for ${divId}` );
-        return;
-    }
-
-    Plotly.restyle( divId, { 'line.width': linewidth  }, [...Array(gd.data.length).keys()] );
-}
+    var gd = document.getElementById( divId );
+    if ( !gd || !gd.data ) { console.warn( `no plotly data for ${divId}` ); return; }
+    Plotly.restyle( divId, { 'line.width': linewidth },
+                    ga.data.plotly._indices( divId, 'linewidth', [0] ) );
+};
 
 ga.data.plotly.linename = function( divId, curvenumber, newlabel ) {
-    const gd = document.getElementById( divId );
-    if ( !gd || !gd.data ) {
-        console.warn( `no plotly data for ${divId}` );
-        return;
-    }
-
-    Plotly.restyle( divId, { 'name': newlabel  }, curvenumber );
-}
+    var gd = document.getElementById( divId );
+    if ( !gd || !gd.data ) { console.warn( `no plotly data for ${divId}` ); return; }
+    Plotly.restyle( divId, { 'name': newlabel }, curvenumber );
+};


### PR DESCRIPTION
## Summary

- Adds ga.data.plotly namespace with errorbars, linewidth, and linename functions wrapping Plotly.restyle()
- Opt-in modeBar buttons (toggle for errorbars, cycle for linewidth) driven by genapp_plotly key in plot config; no effect on existing plots
- Trace selection uses a JS slice-spec overridable per-feature in config; defaults preserve existing hardcoded behaviours
- Custom SVG icons: error bar with caps and centre dot; three bands of increasing thickness for linewidth

## Usage

Add to your plot config:
  genapp_plotly.errorbars: {} to get the toggle button
  genapp_plotly.linewidth: { values: [1,2,3] } to get the cycle button

## Test plan

- [ ] Plot with genapp_plotly.errorbars shows toggle button; clicking hides/shows error bars
- [ ] Plot with genapp_plotly.linewidth shows cycle button; clicking steps through values
- [ ] Plot with neither set is unaffected
- [ ] Multiple plots on same page maintain independent toggle/cycle state

Generated with Claude Code