### PR TITLE
elasticmanager: show ip / status / tag per instance in --status

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -435,6 +435,7 @@ class em_openstack {
         $unknown    = [];
         $all        = [];
         $missing    = [];
+        $instances  = [];
 
         for ( $i = 0; $i < $maximum; ++$i ) {
             if ( !isset( $this->em_state->state->$i ) ) {
@@ -444,6 +445,14 @@ class em_openstack {
 
         foreach ( (array) $this->em_state->state as $k => $v ) {
             $all[] = $k;
+
+            $instances[ $k ] = (object)[
+                "ip"      => isset( $v->network )    ? $v->network    : "?"
+                ,"status" => isset( $v->status )     ? $v->status     : "?"
+                ,"use"    => isset( $v->use_status ) ? $v->use_status : "?"
+                ,"tag"    => empty( $v->use_id )     ? ""             : $v->use_id
+                ];
+
             switch( $v->status ) {
                 case "ACTIVE" : {
                     $active[] = $k;
@@ -504,6 +513,23 @@ class em_openstack {
         }
 
         $this->em_state->release_lock();
+
+        ## per instance detail, sorted by slot number
+
+        ksort( $instances, SORT_NUMERIC );
+
+        $instance_table = sprintf( "%-4s %-15s %-17s %-6s %s\n", "slot", "ip", "status", "use", "tag" );
+
+        foreach ( $instances as $k => $v ) {
+            $instance_table .=
+                sprintf( "%-4s %-15s %-17s %-6s %s\n"
+                         ,$k
+                         ,$v->ip
+                         ,$v->status
+                         ,$v->use
+                         ,$v->tag
+                );
+        }
 
         if ( $update ) {
             $do_reload_state = false;
@@ -580,6 +606,8 @@ class em_openstack {
             . "unknown %d [%s]\n"
             . "missing %d [%s]\n"
             . "\n"
+            . "%s"
+            . "\n"
             . "needed idle $needed_idle\n"
             . "maximum     $maximum\n"
             . "instances to start $instances_to_start\n"
@@ -593,6 +621,7 @@ class em_openstack {
             ,count( $build ), implode( ",", $build )
             ,count( $unknown ), implode( ",", $unknown )
             ,count( $missing ), implode( ",", $missing )
+            ,$instance_table
 
             );
     }


### PR DESCRIPTION
## Why

`em_client.php --status` lists only slot numbers, so working out which VM is
actually running a given job meant opening `em_state.json` and matching by hand.

## What

Adds a per instance table after the existing summary counts, sorted by slot
number (state file order is insertion order, which is arbitrary):

```
slot ip              status            use    tag
1    10.0.10.78      ACTIVE            in use saxsafold-dev:mattia:612d72e0-...
2    10.0.10.25      ACTIVE            in use saxsafold-dev:mattia:ce9b9f80-...
3    10.0.10.249     ACTIVE            in use saxsafold:Octavio:4b1fb020-...
5    10.0.10.173     SHELVED_OFFLOADED idle
6    10.0.10.212     ACTIVE            idle
```

The existing summary lines are unchanged, verified by diffing old against new
output over the same state file.

## Safe as a hot fix, no daemon restart

`status()` is already compiled into the running `em_service.php`, so editing the
file changes only what `em_client.php` renders. The daemon keeps its old copy.
When it is eventually restarted it picks up the new version, but it constructs
with `debug = false` and only passes `status()` to `debug_echo()`, so the table
is built and discarded — no behavior change on that side.

The table is built after `release_lock()` rather than inside the classification
loop, because live jobs contend on the state lock for acquire and release.
Formatting stays outside the critical section.

## Verification

- `php -l` clean on 7.4 and 8.2.
- Ran the real `status()` (`$update = false`, so no OpenStack calls) against the
  live `em_state.json` in a container; summary block byte for byte identical.
- Edge cases exercised: `ERROR` / `BUILD` / unrecognised status, missing
  `network` (renders `?`), empty tag, empty state file.
- No consumer parses this output — `em::status()` in saxsafold `bin/em.php`
  exists on both `main` and `dev`, but its only caller anywhere is
  `bin/em_test.php`, which echoes it. `finalmodel.php` and `loadstructure.php`
  use acquire / ip / id / release only.

## Deploying

Temp file in the same directory so the `mv` is a true rename and no client
invocation can read a partial file:

```bash
cd /src/genapp/languages/html5/openstack/elasticmanager
cp em_openstack.php em_openstack.php.bak
git show origin/php7designer:languages/html5/openstack/elasticmanager/em_openstack.php > em_openstack.php.new
php -l em_openstack.php.new && mv em_openstack.php.new em_openstack.php
php em_client.php --status
```

Rollback: `mv em_openstack.php.bak em_openstack.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)