### PR TITLE
elasticmanager: --probe, ask instances whether they are actually working

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_client.php
+++ b/languages/html5/openstack/elasticmanager/em_client.php
@@ -24,6 +24,12 @@ airavata job status messages
     --acquire flavor tag       : get an instance and tag it supplementary info
     --release id               : release an instance
     --status                   : print status
+    --probe                    : print status, and ask each active instance what
+                                 it is doing. one ssh per instance, so slower.
+                                 load15 is the 15 minute load average: waxsis runs
+                                 one container per frame, so a low instantaneous
+                                 reading is normal between frames but a sustained
+                                 low load15 on a held slot is not
 
 __EOD;
 
@@ -69,6 +75,11 @@ while( count( $u_argv ) && substr( $u_argv[ 0 ], 0, 1 ) == "-" ) {
             $status = true;
             break;
         }
+        case "--probe": {
+            array_shift( $u_argv );
+            $probe = true;
+            break;
+        }
       default:
         error_exit( "\nUnknown option '$u_argv[0]'\n\n$notes" );
     }
@@ -85,8 +96,8 @@ if ( isset( $acquire ) && isset( $release ) ) {
     error_exit( "--acquire & --release are mutually exclusive" );
 }
 
-if ( isset( $status ) ) {
-    echo $em_openstack->status();
+if ( isset( $status ) || isset( $probe ) ) {
+    echo $em_openstack->status( false, isset( $probe ) );
 }
 
 if ( isset( $acquire ) ) {

--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -408,7 +408,68 @@ class em_openstack {
 
 
     # status() - compute status info, optionally update os status
-    function status( $update = false ) {
+    ## held_for() - how long a slot has been held, from acquired_at
+    function held_for( $ts ) {
+        if ( !$ts || ( $s = time() - $ts ) < 0 ) {
+            return "-";
+        }
+        return sprintf( "%dd %02dh", intdiv( $s, 86400 ), intdiv( $s % 86400, 3600 ) );
+    }
+
+    ## probe_instance() - ask the instance what it is actually doing.
+    ## the 15 minute load average is the signal, not a container check:
+    ## finalmodel.php runs one waxsis container per frame, so an instantaneous
+    ## check reads idle in the gaps between frames
+
+    function probe_instance( $ip, &$load, &$waxsis ) {
+        $load   = "?";
+        $waxsis = "?";
+
+        if ( !$this->appconfig_loaded ) {
+            $this->load_appconfig();
+        }
+
+        $p = $this->appconfig->resources->oscluster->properties;
+
+        if ( !isset( $p->sshidentity ) || !isset( $p->sshadmin ) ) {
+            $this->debug_echo( "probe_instance: sshidentity or sshadmin not defined, cannot probe" );
+            return false;
+        }
+
+        $probe_timeout         = 6;
+        $probe_connect_timeout = 4;
+
+        $remote = 'echo L $(cut -d" " -f3 /proc/loadavg); if docker ps >/dev/null 2>&1; then echo W $(docker ps | grep -ci waxsis); else echo W ?; fi';
+
+        $cmd = sprintf( "timeout %d ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=%d %s %s 2>/dev/null"
+                        ,$probe_timeout
+                        ,escapeshellarg( $p->sshidentity )
+                        ,$probe_connect_timeout
+                        ,escapeshellarg( "$p->sshadmin@$ip" )
+                        ,escapeshellarg( $remote )
+            );
+
+        $this->debug_echo( "probe_instance: $cmd" );
+
+        ## deliberately not run_cmd(): an unreachable instance is an expected
+        ## outcome here, not something to log as a command failure
+
+        $out = [];
+        exec( $cmd, $out );
+
+        foreach ( $out as $line ) {
+            if ( preg_match( '/^L\s+(\S+)/', $line, $m ) ) {
+                $load = $m[ 1 ];
+            }
+            if ( preg_match( '/^W\s+(\S+)/', $line, $m ) ) {
+                $waxsis = $m[ 1 ] == "?" ? "?" : ( intval( $m[ 1 ] ) > 0 ? "yes" : "no" );
+            }
+        }
+
+        return $load != "?";
+    }
+
+    function status( $update = false, $probe = false ) {
         $this->debug_echo( "em_openstack: status()" );
 
         $this->em_state->read_lock();
@@ -451,6 +512,9 @@ class em_openstack {
                 ,"status" => isset( $v->status )     ? $v->status     : "?"
                 ,"use"    => isset( $v->use_status ) ? $v->use_status : "?"
                 ,"tag"    => empty( $v->use_id )     ? ""             : $v->use_id
+                ,"held"   => $this->held_for( isset( $v->acquired_at ) ? $v->acquired_at : 0 )
+                ,"load"   => "-"
+                ,"waxsis" => "-"
                 ];
 
             switch( $v->status ) {
@@ -518,17 +582,32 @@ class em_openstack {
 
         ksort( $instances, SORT_NUMERIC );
 
-        $instance_table = sprintf( "%-4s %-15s %-17s %-6s %s\n", "slot", "ip", "status", "use", "tag" );
+        ## probing is one ssh per instance, so only on request and only where
+        ## there is a running OS to answer
+
+        if ( $probe ) {
+            foreach ( $instances as $k => $v ) {
+                if ( $v->status != "ACTIVE" ) {
+                    continue;
+                }
+                $this->probe_instance( $v->ip, $load, $waxsis );
+                $v->load   = $load;
+                $v->waxsis = $waxsis;
+            }
+        }
+
+        $fmt = $probe
+             ? "%-4s %-15s %-17s %-6s %7s %-6s %-8s %s\n"
+             : "%-4s %-15s %-17s %-6s %-8s %s\n";
+
+        $instance_table = $probe
+                        ? sprintf( $fmt, "slot", "ip", "status", "use", "load15", "waxsis", "held", "tag" )
+                        : sprintf( $fmt, "slot", "ip", "status", "use", "held", "tag" );
 
         foreach ( $instances as $k => $v ) {
-            $instance_table .=
-                sprintf( "%-4s %-15s %-17s %-6s %s\n"
-                         ,$k
-                         ,$v->ip
-                         ,$v->status
-                         ,$v->use
-                         ,$v->tag
-                );
+            $instance_table .= $probe
+                             ? sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->load, $v->waxsis, $v->held, $v->tag )
+                             : sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->held, $v->tag );
         }
 
         if ( $update ) {
@@ -950,7 +1029,7 @@ class em_openstack {
                     $this->debug_echo( "error: $v has no ip address defined\n" );
                     exit(-1);
                 }
-                $this->debug_echo("checking for ready $v $os_ip[$v] time waiting ${os_ready_time_waiting}s\n" );
+                $this->debug_echo("checking for ready $v $os_ip[$v] time waiting {$os_ready_time_waiting}s\n" );
 
                 ob_start();
 
@@ -1178,8 +1257,9 @@ class em_openstack {
             foreach ( (array) $this->em_state->state as $k => $v ) {
                 if ( $v->status == "ACTIVE"
                      && $v->use_status == "idle" ) {
-                    $v->use_status = "in use";
-                    $v->use_id     = $tag;
+                    $v->use_status  = "in use";
+                    $v->use_id      = $tag;
+                    $v->acquired_at = time();
                     $this->em_state->save();
                     $number = $k;
                     $ip     = $this->em_state->state->$k->network;
@@ -1209,8 +1289,9 @@ class em_openstack {
             $this->echo_warn( "release $number was not in use" );
             return false;
         }
-        $this->em_state->state->$number->use_status = "idle";
-        $this->em_state->state->$number->use_id     = "";
+        $this->em_state->state->$number->use_status  = "idle";
+        $this->em_state->state->$number->use_id      = "";
+        $this->em_state->state->$number->acquired_at = 0;
         $this->em_state->save();
         return true;
     }


### PR DESCRIPTION
## Why

`--status` tells you *who* holds a slot. It cannot tell you whether anything is
happening on it, which is the actual question when a slot has been held for
days.

Elapsed time cannot answer it either — jobs here legitimately run 7+ days, so a
four day hold is indistinguishable from a healthy run. The signal has to come
from the instance.

## `--probe`

```
php em_client.php --probe
```

ssh's each `ACTIVE` instance and reports its 15 minute load average:

```
slot ip              status            use     load15 waxsis held     tag
1    10.0.10.78      ACTIVE            in use    8.04 yes    4d 02h   saxsafold-dev:mattia:612d72e0
2    10.0.10.25      ACTIVE            in use    7.91 no     0d 06h   saxsafold-dev:mattia:ce9b9f80
3    10.0.10.249     ACTIVE            in use    0.01 no     6d 18h   saxsafold:Octavio:4b1fb020
5    10.0.10.173     SHELVED_OFFLOADED idle         - -      -
6    10.0.10.212     ACTIVE            idle      8.04 yes    -
```

Slot 2 is mid gap between frames and fine. Slot 3 is the one to look at.

**Why load15 and not `docker ps`.** `finalmodel.php:576` calls `run_waxsis`
inside `foreach ( $names as $name )` — one container per frame, torn down and
restarted between frames. An instantaneous container check reports a healthy
multi frame job as idle whenever it lands in a gap. The 15 minute average
smooths across them. The `waxsis` column is a secondary hint only, and reads `?`
when the ssh user cannot query docker, while `load15` still comes back.

No new credentials: this reuses `sshidentity` / `sshadmin` from appconfig, the
same pattern `launch_one()` and `unshelve()` already use for their `/tmp/ready`
probes. Nothing changes on the saxsafold side.

Opt in, because it is one ssh per instance. Bare `--status` stays instant.
Unreachable instances are bounded by `ConnectTimeout=4` inside `timeout 6`;
measured at 16s for four unreachable instances, so roughly 40s worst case at
`maximum` 10. Sequential, not parallel — worth revisiting if that becomes
annoying in practice.

## `acquired_at` / `held`

`acquire()` stamps `acquired_at`, `release()` clears it, and the table gains a
`held` column shown in plain `--status` too.

This is context, not a detector. "load15 0.01" alone could be a job that started
a minute ago; "load15 0.01, held 6d 18h" is a decision. Existing in use slots
read `-` until they turn over.

## Also: a `${var}` interpolation that can strand a slot

`launch_one()` had `${os_ready_time_waiting}s`, deprecated on PHP 8.x. I called
this harmless log noise earlier. It is not.

The notice is emitted when `em_openstack.php` is compiled, so it affects every
`em_client.php` run, and with `display_errors` on it goes to **stdout**. That
breaks the acquire contract: `bin/em.php:69-75` in saxsafold reads `$arr[0]` as
the instance id and requires `/^\d+$/`. A leading notice makes that
`"Deprecated:"`, so `acquire()` returns false — *after* `em_client.php` has
already marked the slot in use. `has_instance` stays false, so neither the
destructor nor the shutdown handler releases it. Stranded slot, from a
deprecation notice.

Whether it currently fires depends on `display_errors` in that container, which
I could not check, and the container is `FROM debian` unpinned so a rebuild
could change the PHP version under it. The fix is two characters.

Verified on 8.2 with `display_errors=1`: acquire stdout is now `6 10.0.10.212`
and `$arr[0]` passes the regex. Whole file scan reports no remaining
deprecations.

## Restart impact

Client side only. `em_openstack.php` is `shared` and `em_client.php` is
`client`, so both are hot; the daemon keeps its loaded copy. `acquired_at`
survives the running daemon's `reload_state()`, which only rewrites `status` for
instances it still matches, so the new field is not clobbered by the old code.

## Testing

In a container against the real state file, with a fake `ssh` on PATH to
simulate instance responses:

- plain `--status`: `held` column present, no probe columns, no ssh
- `--probe` with instances answering: both layouts render, shelved slot not probed
- held but idle instance: `load15 0.01`, `waxsis no` — the signature we are after
- ssh user cannot query docker: `waxsis ?`, `load15` still reported
- unreachable instance, real ssh against a blackholed IP: `?`, bounded at 16s for four
- `acquired_at` round trip: stamped on acquire, `held` renders, cleared to 0 on
  release, reverts to `-`
- `php -l` clean on 7.4 and 8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)