### PR TITLE
elasticmanager: em_install.php, accept a bare branch name for --ref

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -369,11 +369,27 @@ if ( $fetch ) {
     }
 }
 
-git( "rev-parse --verify " . escapeshellarg( "$ref^{commit}" ), $code );
+## accept a bare branch name for a remote branch, the way git checkout does.
+## git rev-parse does not do that on its own, so try origin/<ref> too
 
-if ( $code ) {
-    fail( "ref '$ref' not found, try --fetch" );
+$resolved = "";
+
+foreach ( [ $ref, "origin/$ref" ] as $try ) {
+    git( "rev-parse --verify " . escapeshellarg( "$try^{commit}" ), $code );
+
+    if ( !$code ) {
+        $resolved = $try;
+        break;
+    }
 }
+
+if ( !strlen( $resolved ) ) {
+    fail( $fetch
+          ? "ref '$ref' not found after fetching, tried '$ref' and 'origin/$ref'"
+          : "ref '$ref' not found as '$ref' or 'origin/$ref', try --fetch" );
+}
+
+$ref = $resolved;
 
 ## capture the prefix while git is still running from $emdir, then move it to
 ## the repo root for everything after


### PR DESCRIPTION
## The problem

```
$ php em_install.php --ref em-probe
ERROR: ref 'em-probe' not found, try --fetch
$ php em_install.php --fetch --ref em-probe
fetching origin...
ERROR: ref 'em-probe' not found, try --fetch
```

Two things wrong: a bare branch name does not resolve, and the error keeps
telling you to fetch after you just did.

`git rev-parse` looks in `refs/heads` and `refs/remotes/<remote>`, so
`origin/em-probe` resolves while `em-probe` does not. It does not DWIM bare
names to remote branches the way `git checkout` does, which is what the usage
here naturally invites.

## The fix

Try `origin/<ref>` as a fallback, and make the failure message name both forms
it tried and only suggest `--fetch` when a fetch has not already happened.

The resolved ref is echoed in the existing `ref :` output line, so the fallback
is visible rather than silent:

```
$ php em_install.php --fetch --ref em-feature
ref     : origin/em-feature (a04657d)
```

## Testing

- bare name, not fetched: `ref 'em-feature' not found as 'em-feature' or 'origin/em-feature', try --fetch`
- bare name with `--fetch`: resolves to `origin/em-feature`, the case that looped before
- explicit `origin/` form: unchanged
- genuinely bad name after fetching: `not found after fetching, tried 'no-such-branch' and 'origin/no-such-branch'`, no misleading fetch suggestion
- tags and raw shas still resolve, so general ref handling is not narrowed
- `php -l` clean on 7.4 and 8.2

## Restart impact

`em_install.php` is `standalone` scope, so this changes nothing about the
running system. Replacing it while it runs is safe: PHP has already compiled
the running copy and the replace is an atomic rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)