### PR TITLE
elasticmanager: em_install.php does nothing without an action option

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -39,7 +39,8 @@ replace by rename so a concurrent em_client.php can never read a partial file
     --rollback          : restore the most recent backup set
     --backups           : list backup sets
 
-    With no action given, --diff is assumed.
+    One of --diff, --install, --rollback or --backups must be given. With no
+    action this prints help and does nothing.
 
     Restart impact is reported per file. Nothing here restarts the daemon; when
     a restart is needed the command is printed.
@@ -311,8 +312,11 @@ if ( count( $u_argv ) ) {
     fail( "unexpected argument '$u_argv[0]'\n$notes" );
 }
 
+## no action without being asked for one, not even a read only one
+
 if ( !strlen( $action ) ) {
-    $action = "diff";
+    echo $notes;
+    exit;
 }
 
 $backuproot = ( getenv( "HOME" ) ? getenv( "HOME" ) : $emdir ) . "/.em_install_backups";


### PR DESCRIPTION
## Why

`em_install.php` defaulted to `--diff` when no action was given, so a bare
invocation went and did something. That breaks the rule these tools follow, and
the rule covers read-only actions too — a dry run is still an action, and
`--fetch` on its own would reach out to origin.

`em_client.php` has always done this correctly, and `em_log.php` follows it.
This brings `em_install.php` into line.

## Change

One of `--diff`, `--install`, `--rollback` or `--backups` must be given.
Anything else prints help and exits.

## Behaviour change worth knowing before merging

```
php em_install.php --fetch
```

no longer shows a dry run — it prints help, and does not fetch. The equivalent
is now:

```
php em_install.php --fetch --diff
```

That is the command from the last few sessions, so it is worth adjusting muscle
memory. `--fetch --install` and `--install` are unaffected.

## Testing

- no arguments: help only, no git access, no fetch, exit 0
- `--fetch` alone: help only, and origin is not contacted
- `--fetch --diff`: unchanged
- `--install`: unchanged
- `php -l` clean on 7.4 and 8.2

## Restart impact

`em_install.php` is `standalone` scope. Nothing to restart.