### PR TITLE
elasticmanager: do not wipe state when openstack server list fails

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -323,6 +323,18 @@ class em_openstack {
             $cmd = "openstack server list -c ID -c Name -c Status -c Networks";
             $regexp = "/\| $project-run-$this->idprefix-$this->id-$this->flavor-/";
             $results_all = $this->run_cmd( $cmd, false, true );
+
+            ## a failed list means "we do not know what is out there", not "there
+            ## is nothing out there". believing it drops every tracked instance,
+            ## in use included, and the next loop launches replacements for all
+            ## of them. a DNS outage did exactly that on 2025-08-04.
+
+            if ( $this->run_cmd_last_error_code ) {
+                $this->echo_warn( "reload_state() could not list servers for project $project, leaving state untouched"
+                                  ,implode( " ", $results_all ) );
+                return false;
+            }
+
             $results = preg_grep( $regexp, $results_all );
             $this->debug_echo( "cmd : $cmd\n" . implode( "\n", $results ) );
 
@@ -402,8 +414,8 @@ class em_openstack {
         if ( $this->debug ) {
             debug_json( "reload state em_state - after save", $this->em_state->state );
         }
-            
-        # $this->error_exit( "em_openstack:reload_state() - not yet implemented" );
+
+        return true;
     }
 
 
@@ -1206,8 +1218,16 @@ class em_openstack {
 
     ## os interaction
 
-    ## echo_warn() - print warning, perhaps to stderr later
-    function echo_warn( $msg ) {
+    ## echo_warn() - print warning, perhaps to stderr later.
+    ## $detail was already being passed at one call site but the signature only
+    ## took $msg, so PHP dropped it: 423 boot failures on 2025-08-04 were logged
+    ## with no trace of the cause. the log is one line per entry and em_log.php
+    ## parses it that way, so detail is flattened rather than wrapped.
+
+    function echo_warn( $msg, $detail = "" ) {
+        if ( strlen( $detail ) ) {
+            $msg .= " [" . preg_replace( '/\s*\R\s*/', " | ", trim( $detail ) ) . "]";
+        }
         $this->log( "WARNING: $msg" );
         echo "WARNING: $msg\n";
     }


### PR DESCRIPTION
## The bug

`reload_state()` called `run_cmd()` with `exit_if_error` false and never looked
at the return code:

```php
$results_all = $this->run_cmd( $cmd, false, true );
$results     = preg_grep( $regexp, $results_all );
```

When the command failed, the error text became the server list, matched nothing,
and `$current` came back empty. The reconcile loop then dropped every tracked
instance as "state inconsistency, entry in state not in current" — in use
included.

## What it did on 2025-08-04

DNS inside the container stopped resolving `js2.jetstream-cloud.org`:

```
Failed to resolve 'js2.jetstream-cloud.org' ([Errno -3] Temporary failure in name resolution)
```

```
18:29:58 - run_cmd() openstack server list ... failed error code 1
18:29:58 - WARNING: state inconsistency, entry in state not in current   (x6)
18:30:28 - launch 0
18:30:48 - launch 1   ... and so on for three hours
```

Six instances dropped in one second, then the daemon spent three hours
launching replacements for slots it believed were empty. That is the 423 boot
failures and 42 "could not start expected instances" in the log — all of them
inside one window, all downstream of the state wipe rather than a separate
fault.

The repeated `release N was not in use` warnings elsewhere in the log are the
other half: jobs whose slot the manager had forgotten while they were still
running.

This has happened on four days across the log (6, 6, 2 and 1 entries wiped).
These DNS outages are Jetstream-wide and clear on their own, which is exactly
why reacting to them destructively is the wrong move.

## The fix

A failed list means *we do not know what is out there*, not *there is nothing
out there*. Warn, return false, leave the state alone, let the next loop retry.

An empty list that genuinely succeeded is still believed — that legitimately
means the pool is empty, and refusing to act on it would wedge the manager.
The exit code is the discriminator, not the emptiness.

With this in place a DNS outage becomes: rebalancing pauses, `acquire` and
`release` keep working normally since they only touch the state file, and
everything resumes when DNS returns. One failed API call per 30s loop, no storm.

## Also: echo_warn was dropping its second argument

`echo_warn( $msg )` was already being called with two arguments at
`em_openstack.php:872`, the second being the actual openstack error output. PHP
discarded it silently, which is why all 423 boot failures were logged with no
trace of the cause and this took a log dive to reconstruct.

Now `echo_warn( $msg, $detail = "" )`. Detail is flattened onto one line because
`em_log.php` parses the log line by line.

## Testing

Reproduced the failure with a fake `openstack` returning that exact DNS error
and exit 1, against a state file holding one in-use and one idle slot:

**Before** — state wiped, in-use entry destroyed:
```
WARNING: state inconsistency, entry in state not in current  (x2)
state now : {}
```

**After** — state intact, cause now recorded:
```
WARNING: reload_state() could not list servers for project TG-MCB170057, leaving state untouched
         [Unable to establish connection ... Temporary failure in name resolution ...]
reload_state() returned: false
state now : {"1":{... "use_status":"in use","use_id":"saxsafold-dev:mattia:LIVEJOB"},"6":{...}}
```

**After, healthy list** — normal reconcile, returns true, no warnings.

`php -l` clean on 7.4 and 8.2.

## Restart impact

`em_openstack.php` is `shared`, so installing it is hot. But `reload_state()` is
only ever reached from the daemon (`server_start()`, and `status( true )` which
only the daemon calls), so **the fix does not take effect until the daemon is
restarted**. Installing alone changes nothing about this behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)