### PR TITLE
elasticmanager: em_install.php missed newly added files, and undersold restarts

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -72,7 +72,12 @@ $em_scope = [
     ,"em_test.php"      => "standalone"
     ,"em_test_mail.php" => "standalone"
     ,"em_install.php"   => "standalone"
+    ,"em_log.php"       => "standalone"
     ];
+
+## anything the ref carries that is not classified above
+
+define( "EM_UNCLASSIFIED", "unclassified" );
 
 $em_scope_notes = [
     "client"      => "hot, applies to the next em_client.php run"
@@ -80,6 +85,7 @@ $em_scope_notes = [
     ,"daemon"     => "no effect until the daemon is restarted"
     ,"config"     => "no effect until the daemon is restarted, config is read once at startup"
     ,"standalone" => "no effect on the running system"
+    ,"unclassified" => "not classified in em_install.php, assume it may need a daemon restart"
     ];
 
 function fail( $msg ) {
@@ -407,15 +413,34 @@ if ( count( $toplevel ) && is_dir( $toplevel[ 0 ] ) ) {
     $gitdir = $toplevel[ 0 ];
 }
 
+## enumerate from the ref rather than from $em_scope. $em_scope classifies
+## restart impact, it is not the file list: driving the loop from it meant a
+## newly added file nobody had listed there was silently never installed.
+
+$reffiles = [];
+
+foreach ( git( "ls-tree " . escapeshellarg( rtrim( $ref, "/" ) . ":" . rtrim( $prefix, "/" ) ), $code ) as $l ) {
+
+    ## regular blobs only, the tree also carries the vendor symlink
+
+    if ( preg_match( '/^(100644|100755) blob \S+\t(.+)$/', $l, $m ) ) {
+        $reffiles[] = $m[ 2 ];
+    }
+}
+
+if ( $code || !count( $reffiles ) ) {
+    fail( "could not list the elastic manager directory in $ref" );
+}
+
 foreach ( $only as $f ) {
-    if ( !isset( $em_scope[ $f ] ) ) {
-        fail( "'$f' is not an elastic manager file" );
+    if ( !in_array( $f, $reffiles ) ) {
+        fail( "'$f' is not in $ref, known files: " . implode( " ", $reffiles ) );
     }
 }
 
 $changed = [];
 
-foreach ( array_keys( $em_scope ) as $f ) {
+foreach ( $reffiles as $f ) {
     if ( count( $only ) && !in_array( $f, $only ) ) {
         continue;
     }
@@ -441,7 +466,7 @@ echo "pending changes:\n\n";
 $scopes_seen = [];
 
 foreach ( $changed as $f ) {
-    $scope = $em_scope[ $f ];
+    $scope = isset( $em_scope[ $f ] ) ? $em_scope[ $f ] : EM_UNCLASSIFIED;
     $scopes_seen[ $scope ] = true;
     echo sprintf( "  %-18s %-11s %s\n", $f, "[$scope]", $em_scope_notes[ $scope ] );
 }
@@ -603,7 +628,7 @@ echo "  ok\n\n";
 
 ## ---------------- what is left to do ----------------
 
-$needs_restart = array_intersect( [ "daemon", "config" ], array_keys( $scopes_seen ) );
+$needs_restart = array_intersect( [ "daemon", "config", EM_UNCLASSIFIED ], array_keys( $scopes_seen ) );
 $has_shared    = isset( $scopes_seen[ "shared" ] );
 
 echo "installed " . count( $installed ) . " file" . ( count( $installed ) == 1 ? "" : "s" ) . " from $ref\n";
@@ -613,7 +638,7 @@ echo "rollback : php $self --rollback\n\n";
 if ( count( $needs_restart ) ) {
     echo "A DAEMON RESTART IS REQUIRED for these changes to take effect:\n";
     foreach ( $changed as $f ) {
-        if ( in_array( $em_scope[ $f ], [ "daemon", "config" ] ) ) {
+        if ( in_array( isset( $em_scope[ $f ] ) ? $em_scope[ $f ] : EM_UNCLASSIFIED, [ "daemon", "config", EM_UNCLASSIFIED ] ) ) {
             echo "  $f\n";
         }
     }
@@ -632,8 +657,22 @@ if ( count( $needs_restart ) ) {
 
     echo "  cd $emdir && ./em_start.sh\n\n";
 } else if ( $has_shared ) {
-    echo "No restart needed for the running daemon to stay correct. It keeps its\n"
-        . "loaded copy and will pick these up whenever it is next restarted.\n\n";
+    echo "The daemon stays correct without a restart, but it keeps its loaded copy,\n"
+        . "so it is STILL RUNNING THE OLD CODE. Anything in this change that affects\n"
+        . "daemon behaviour (reload_state, shelve, unshelve, launch_one, the service\n"
+        . "loop) does not take effect until you restart it. Client side changes\n"
+        . "(acquire, release, status, probe) are already live.\n\n";
+
+    echo "pool: " . pool_summary() . "\n\nTo restart if this change needs it:\n\n";
+
+    if ( ( $pid = service_pid() ) !== false ) {
+        echo "  kill $pid\n";
+    } else {
+        echo "  ## daemon pid not readable from the lock file, find it by hand\n";
+        echo "  pkill -f 'php em_service.php'\n";
+    }
+
+    echo "  cd $emdir && ./em_start.sh\n\n";
 } else {
     echo "No restart needed.\n\n";
 }


### PR DESCRIPTION
Two bugs, both found by actually installing #53 on the box.

## 1. A newly added file was never installed

`em_log.php` merged, `em_install.php --fetch --install` reported the other two files and said nothing about it, and the file never reached the container.

The pending-changes loop iterated `array_keys( $em_scope )` — a hardcoded table of filenames — so anything not listed there was never compared against the ref at all. `$em_scope` exists to classify restart impact; using it as the file list meant every future new file would be silently skipped the same way.

Files now come from `git ls-tree` of the elasticmanager directory in the ref, regular blobs only so the `vendor` symlink is skipped. A file the table does not classify shows as `unclassified` and is treated as possibly needing a restart, rather than being ignored:

```
  em_future.php      [unclassified] not classified in em_install.php, assume it may need a daemon restart
  em_log.php         [standalone] no effect on the running system
```

`--only` now validates against the ref's actual contents and lists them on a bad name. `em_log.php` is added to the scope table as `standalone`.

## 2. "No restart needed" was true and misleading

After installing a `shared` file the tool said:

> No restart needed for the running daemon to stay correct. It keeps its loaded copy and will pick these up whenever it is next restarted.

Every word is accurate and the conclusion an operator draws from it is wrong. That message is why the `reload_state()` guard from #55 was installed and left inert — it lives in `em_openstack.php`, which is `shared`, but it is only ever reached from the daemon, so it does precisely nothing until a restart.

The scope model conflates "does the daemon stay correct without a restart" with "does this change take effect without a restart". A per-file scope cannot tell those apart, since `em_openstack.php` holds both client and daemon code, so the message now states both plainly and always offers the restart:

```
The daemon stays correct without a restart, but it keeps its loaded copy,
so it is STILL RUNNING THE OLD CODE. Anything in this change that affects
daemon behaviour (reload_state, shelve, unshelve, launch_one, the service
loop) does not take effect until you restart it. Client side changes
(acquire, release, status, probe) are already live.

pool: 1 in use [2], 0 mid operation []

To restart if this change needs it:
  kill <pid>
  cd /src/genapp/languages/html5/openstack/elasticmanager && ./em_start.sh
```

## Testing

- two new files added upstream, one classified one not: both detected, both installed, the unclassified one raises the restart notice
- the installed `em_log.php` runs
- shared-scope-only install: prints the new message and the restart commands
- `--only` with an unknown name: rejected, real file list shown
- `php -l` clean on 7.4 and 8.2

## Restart impact

`em_install.php` is `standalone`. Nothing to restart for this change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
