### PR TITLE
elasticmanager: keep runtime state out of the repo, and out of installs

### DIFF
--- a/languages/html5/openstack/elasticmanager/.gitignore
+++ b/languages/html5/openstack/elasticmanager/.gitignore
@@ -1,0 +1,20 @@
+## Runtime state and transient files. These are produced by a running manager
+## and are per deployment, never part of the repo.
+##
+## em_state.json in particular is the live pool bookkeeping. If it were ever
+## committed, both "git checkout -- ." and em_install.php would overwrite a
+## running pool's state with a stale snapshot. em_install.php refuses to
+## install anything matching these names as a second line of defence.
+
+em_state.json
+*.log
+nohup.out
+
+## em_install.php staging and rollback artefacts, normally removed on the way
+## through but left behind if it is interrupted
+
+*.new.*
+*.rollback.*
+
+## appconfig.json and secrets.json are already covered by the repo root
+## .gitignore

--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -75,6 +75,7 @@ $em_scope = [
     ,"em_test_mail.php" => "standalone"
     ,"em_install.php"   => "standalone"
     ,"em_log.php"       => "standalone"
+    ,".gitignore"       => "standalone"
     ];
 
 ## anything the ref carries that is not classified above
@@ -140,6 +141,30 @@ function validate( $path, $name ) {
 function git_mode( $ref, $path ) {
     $out = git( "ls-tree " . escapeshellarg( $ref ) . " -- " . escapeshellarg( $path ) );
     return ( count( $out ) && substr( $out[ 0 ], 0, 6 ) == "100755" ) ? 0755 : 0644;
+}
+
+## runtime_files() - names that belong to a running manager, never installed.
+## taken from em_config.json where it names them, so a renamed state file or
+## logfile is still protected, plus what em_start.sh produces.
+
+function runtime_files() {
+    $cfg   = em_cfg();
+    $names = [ "service.log", "nohup.out" ];
+
+    $from_cfg = [
+        isset( $cfg->logfile )          ? $cfg->logfile          : ""
+        ,isset( $cfg->files->state )    ? $cfg->files->state     : ""
+        ,isset( $cfg->files->appconfig )? $cfg->files->appconfig : ""
+        ,isset( $cfg->files->secrets )  ? $cfg->files->secrets   : ""
+        ];
+
+    foreach ( $from_cfg as $n ) {
+        if ( strlen( $n ) ) {
+            $names[] = basename( $n );
+        }
+    }
+
+    return array_values( array_unique( $names ) );
 }
 
 ## em_cfg() - em_config.json, or null
@@ -595,7 +620,27 @@ if ( $code || !count( $reffiles ) ) {
     fail( "could not list the elastic manager directory in $ref" );
 }
 
+## a runtime file committed by mistake must never be installed over the live
+## one. say so rather than skipping quietly, it means the repo needs fixing
+
+$protected = runtime_files();
+$blocked   = array_values( array_intersect( $reffiles, $protected ) );
+
+if ( count( $blocked ) ) {
+    echo "WARNING: $ref contains runtime files, refusing to install them:\n";
+    foreach ( $blocked as $b ) {
+        echo "  $b\n";
+    }
+    echo "  these belong to the running manager. add them to .gitignore and\n"
+        . "  git rm --cached them in the repo.\n\n";
+
+    $reffiles = array_values( array_diff( $reffiles, $protected ) );
+}
+
 foreach ( $only as $f ) {
+    if ( in_array( $f, $protected ) ) {
+        fail( "'$f' is a runtime file of the running manager, refusing to install it" );
+    }
     if ( !in_array( $f, $reffiles ) ) {
         fail( "'$f' is not in $ref, known files: " . implode( " ", $reffiles ) );
     }


### PR DESCRIPTION
## Why

`em_state.json`, `em_saxsafold.log`, `service.log` and `nohup.out` sit in the elasticmanager directory as untracked files. Untracked is not the same as ignored — they are one `git add -A` in that repo away from being committed.

If `em_state.json` ever were committed, two separate things would then overwrite a running pool's bookkeeping with a stale snapshot:

- `git checkout -- .`, which is part of the documented way to reconcile the deployment clone after a hot install
- `em_install.php` itself, since #56 changed it to enumerate files from `git ls-tree` rather than a hardcoded list

I hit exactly this while testing the reconcile procedure — a fixture that happened to have `em_state.json` tracked lost its live state to `git checkout -- .`. The production clone is fine today; this closes the door.

## Two changes

**A `.gitignore` in the elasticmanager directory** covering the runtime state, logs, and `em_install.php`'s own staging and rollback artefacts.

**A guard in `em_install.php`** that refuses to install anything matching a runtime file name, as a second line of defence for the case where one gets committed anyway:

```
WARNING: origin/php7designer contains runtime files, refusing to install them:
  em_saxsafold.log
  em_state.json
  these belong to the running manager. add them to .gitignore and
  git rm --cached them in the repo.
```

It warns rather than skipping silently, because a runtime file appearing in the ref means the repo needs fixing and that should be visible. The rest of the install proceeds normally.

The protected names come from `em_config.json` where it names them (`logfile`, `files->state`, `files->appconfig`, `files->secrets`), so a renamed state file or logfile is still covered, plus `service.log` and `nohup.out` from `em_start.sh`. `--only` cannot be used to force one through.

`.gitignore` is classified `standalone` in the scope table so it does not show up as unclassified.

## Testing

With a ref that has `em_state.json` and `em_saxsafold.log` committed by mistake, alongside a genuine `em_openstack.php` change, against a live state file holding an in-use slot:

- `--diff` and `--install` both name the runtime files and refuse them
- the genuine change still installs
- the live `em_state.json` is byte identical afterwards, still holding its in-use entry
- the live log is untouched
- `--only em_state.json --install` is rejected outright
- `php -l` clean on 7.4 and 8.2

## Effect on the deployment clone

After installing this, `git status` in `/src/genapp` stops listing the runtime files, so the reconcile procedure gets less ambiguous — anything unexpected in `git status` is then genuinely unexpected.

## Restart impact

`em_install.php` and `.gitignore` are both `standalone`. Nothing to restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
