### PR TITLE
elasticmanager: em_install.php reinstall loop, and the .gitignore restart claim

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -143,6 +143,28 @@ function git_mode( $ref, $path ) {
     return ( count( $out ) && substr( $out[ 0 ], 0, 6 ) == "100755" ) ? 0755 : 0644;
 }
 
+## ref_blob() / work_blob() - object ids for the two sides of a comparison.
+##
+## these exist because "git diff <ref> -- <path>" consults the index, so a file
+## that is not tracked in this clone reads as different forever no matter how
+## many times it is installed: em_log.php and .gitignore reinstalled on every
+## single run. hashing the content is index independent, and an absent file
+## hashes to "" so a new file still registers as a change.
+
+function ref_blob( $ref, $path ) {
+    $out = git( "rev-parse --verify --quiet " . escapeshellarg( "$ref:$path" ), $code );
+    return ( !$code && count( $out ) ) ? trim( $out[ 0 ] ) : "";
+}
+
+function work_blob( $file ) {
+    if ( !file_exists( $file ) ) {
+        return "";
+    }
+
+    $out = run( "git hash-object " . escapeshellarg( $file ), $code );
+    return ( !$code && count( $out ) ) ? trim( $out[ 0 ] ) : "";
+}
+
 ## scope_of() - restart impact for a file, classified or not.
 ## an unlisted file is only treated as possibly needing a restart when the
 ## daemon could actually load it: it requires php and reads json config, so a
@@ -671,9 +693,7 @@ foreach ( $reffiles as $f ) {
         continue;
     }
 
-    git( "diff --quiet " . escapeshellarg( $ref ) . " -- " . escapeshellarg( "$prefix$f" ), $code );
-
-    if ( $code == 1 ) {
+    if ( ref_blob( $ref, "$prefix$f" ) !== work_blob( "$emdir/$f" ) ) {
         $changed[] = $f;
     }
 }
@@ -732,11 +752,31 @@ if ( in_array( "em_config.json", $changed ) ) {
 
 if ( $action == "diff" ) {
     foreach ( $changed as $f ) {
-        ## -R so the diff reads working tree -> ref, the direction install applies
 
-        $d = git( "diff -R --no-color " . escapeshellarg( $ref ) . " -- " . escapeshellarg( "$prefix$f" ) );
+        ## plain diff against the ref content, for the same reason the
+        ## comparison above does not use git diff: it must not depend on
+        ## whether this clone happens to track the file
+
+        $tmp = "$emdir/$f.diff." . getmypid();
+
+        system( "git -C " . escapeshellarg( $gitdir ) . " show " . escapeshellarg( "{$ref}:{$prefix}{$f}" ) . " > " . escapeshellarg( $tmp ) . " 2>/dev/null", $code );
 
         echo str_repeat( "-", 72 ) . "\n";
+
+        if ( $code ) {
+            echo "  could not read $f from $ref\n";
+            @unlink( $tmp );
+            continue;
+        }
+
+        $d = run( sprintf( "diff -u --label %s --label %s %s %s"
+                           ,escapeshellarg( "$f  (installed)" )
+                           ,escapeshellarg( "$f  ($ref)" )
+                           ,escapeshellarg( file_exists( "$emdir/$f" ) ? "$emdir/$f" : "/dev/null" )
+                           ,escapeshellarg( $tmp ) ) );
+
+        @unlink( $tmp );
+
         if ( count( $d ) ) {
             echo implode( "\n", $d ) . "\n";
         }

--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -143,6 +143,24 @@ function git_mode( $ref, $path ) {
     return ( count( $out ) && substr( $out[ 0 ], 0, 6 ) == "100755" ) ? 0755 : 0644;
 }
 
+## scope_of() - restart impact for a file, classified or not.
+## an unlisted file is only treated as possibly needing a restart when the
+## daemon could actually load it: it requires php and reads json config, so a
+## .gitignore, a README or a shell script cannot change how it runs and saying
+## otherwise just trains the operator to ignore the warning.
+
+function scope_of( $f ) {
+    global $em_scope;
+
+    if ( isset( $em_scope[ $f ] ) ) {
+        return $em_scope[ $f ];
+    }
+
+    return in_array( pathinfo( $f, PATHINFO_EXTENSION ), [ "php", "json" ] )
+         ? EM_UNCLASSIFIED
+         : "standalone";
+}
+
 ## runtime_files() - names that belong to a running manager, never installed.
 ## taken from em_config.json where it names them, so a renamed state file or
 ## logfile is still protected, plus what em_start.sh produces.
@@ -674,7 +692,7 @@ echo "pending changes:\n\n";
 $scopes_seen = [];
 
 foreach ( $changed as $f ) {
-    $scope = isset( $em_scope[ $f ] ) ? $em_scope[ $f ] : EM_UNCLASSIFIED;
+    $scope = scope_of( $f );
     $scopes_seen[ $scope ] = true;
     echo sprintf( "  %-18s %-11s %s\n", $f, "[$scope]", $em_scope_notes[ $scope ] );
 }
@@ -846,7 +864,7 @@ echo "rollback : php $self --rollback\n\n";
 if ( count( $needs_restart ) ) {
     echo "A DAEMON RESTART IS REQUIRED for these changes to take effect:\n";
     foreach ( $changed as $f ) {
-        if ( in_array( isset( $em_scope[ $f ] ) ? $em_scope[ $f ] : EM_UNCLASSIFIED, [ "daemon", "config", EM_UNCLASSIFIED ] ) ) {
+        if ( in_array( scope_of( $f ), [ "daemon", "config", EM_UNCLASSIFIED ] ) ) {
             echo "  $f\n";
         }
     }


### PR DESCRIPTION
Two `em_install.php` bugs, both surfaced by installing the new `.gitignore`.

## 1. Untracked files reinstalled on every run, forever

```
php em_install.php --fetch --install   ->  installed .gitignore, em_log.php
php em_install.php --fetch --install   ->  installed .gitignore, em_log.php
php em_install.php --fetch --install   ->  installed .gitignore, em_log.php
```

Never converged. Each run reported them pending, installed them, took a backup, and the next run said exactly the same.

Change detection used `git diff --quiet <ref> -- <path>`, and **`git diff` against a commit consults the index**. `em_log.php` and `.gitignore` are untracked in the deployment clone, whose index still sits at the image-build commit. Git sees "present in ref, absent from index" and reports a difference regardless of what is actually on disk, so no amount of installing could ever satisfy it.

This did not show up before because every file involved until now was already tracked.

Detection now compares content directly: `git rev-parse <ref>:<path>` against `git hash-object` of the working file. That is index independent, and an absent file hashes to `""` so a genuinely new file still registers.

The diff display had the same blind spot and is now a plain `diff -u` against the ref content, which also reads better:

```
--- em_log.php  (installed)
+++ em_log.php  (origin/php7designer)
-echo "log\n";
+echo "log v2\n";
```

## 2. A .gitignore does not need a daemon restart

```
  .gitignore         [unclassified] not classified in em_install.php, assume it may need a daemon restart
...
A DAEMON RESTART IS REQUIRED for these changes to take effect:
  .gitignore
```

That particular instance was a bootstrap artifact — the classifying `em_install.php` was the one already in memory, which predated `.gitignore` being added to the scope table — but the default behind it is wrong regardless, and any future README, shell script or dotfile would do the same.

#56 added `unclassified` as a conservative default. Conservative was the right instinct in the wrong place: a warning that fires on files which provably cannot matter is one the operator learns to skip, and that costs us the times it is real.

An unlisted file is now only restart-worthy when the daemon could load it. It requires `php` and reads `json` config; anything else cannot change how it runs:

```
  .gitignore         [standalone] no effect on the running system
  README.md          [standalone] no effect on the running system
  helper.sh          [standalone] no effect on the running system
  em_future.php      [unclassified] not classified in em_install.php, assume it may need a daemon restart
  extra.json         [unclassified] not classified in em_install.php, assume it may need a daemon restart
```

and the restart notice names only the last two. Both scope lookups go through one `scope_of()` so the table and the fallback cannot drift apart.

## Testing

Reproducing the production case — files present in the ref but untracked in the clone:

- run 1 installs them, runs 2 and 3 report nothing to install
- git still lists them as untracked afterwards, confirming the fix does not depend on reconciling the clone
- a real edit to one of those files is still detected, shows a correct diff, and converges after installing
- five new unlisted files covering both sides of the scope rule classify as shown above
- `php -l` clean on 7.4 and 8.2

## Restart impact

`em_install.php` is `standalone`. Nothing to restart. The running copy is already compiled, so as always both fixes apply from the next invocation onward — expect one more redundant reinstall of `.gitignore` and `em_log.php` on the run that installs this, then convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
