### PR TITLE
elasticmanager: record probe samples, and report load as a fraction of the box

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_config.json
+++ b/languages/html5/openstack/elasticmanager/em_config.json
@@ -14,6 +14,10 @@
         ,"service_loop" : 30
         ,"acquire_wait" : 15
     }
+    ,"probe" : {
+        "interval"  : 300
+        ,"history"  : "em_probe.log"
+    }
     ,"flavors" : {
         "m3.2xl" : {
             "idle" : 1

--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -196,6 +196,7 @@ function runtime_files() {
         ,isset( $cfg->files->state )    ? $cfg->files->state     : ""
         ,isset( $cfg->files->appconfig )? $cfg->files->appconfig : ""
         ,isset( $cfg->files->secrets )  ? $cfg->files->secrets   : ""
+        ,isset( $cfg->probe->history )  ? $cfg->probe->history   : ""
         ];
 
     foreach ( $from_cfg as $n ) {

--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -423,6 +423,66 @@ class em_openstack {
 
 
     # status() - compute status info, optionally update os status
+    ## load_pct() - load15 as a percentage of the machine.
+    ## the raw figure means nothing without the core count, and the core count
+    ## changes with the flavor, so everything downstream should use this
+
+    function load_pct( $load, $cores ) {
+        if ( !is_numeric( $load ) || !is_numeric( $cores ) || $cores <= 0 ) {
+            return "?";
+        }
+
+        return (string) round( 100 * $load / $cores );
+    }
+
+    ## probe_sample() - probe every ACTIVE instance and append one line each to
+    ## the probe history. records every sample, not just interesting ones: no
+    ## threshold can be chosen honestly until we know what a working job and an
+    ## idle gap actually look like over time.
+
+    function probe_sample() {
+        if ( !isset( $this->em_config->probe->history ) ) {
+            return false;
+        }
+
+        $this->em_state->read_no_lock();
+
+        if ( !isset( $this->em_state->state ) ) {
+            return false;
+        }
+
+        $lines = [];
+
+        foreach ( (array) $this->em_state->state as $k => $v ) {
+            if ( !isset( $v->status ) || $v->status != "ACTIVE" || !isset( $v->network ) ) {
+                continue;
+            }
+
+            $ok = $this->probe_instance( $v->network, $load, $waxsis, $cores );
+
+            $lines[] = sprintf( "%s slot=%s cores=%s load15=%s pct=%s waxsis=%s use=%s ip=%s tag=%s%s"
+                                ,$this->timestamp()
+                                ,$k
+                                ,$cores
+                                ,$load
+                                ,$this->load_pct( $load, $cores )
+                                ,$waxsis
+                                ,( isset( $v->use_status ) && $v->use_status == "in use" ) ? "inuse" : "idle"
+                                ,$v->network
+                                ,empty( $v->use_id ) ? "-" : $v->use_id
+                                ,$ok ? "" : " error=" . str_replace( " ", "_", $this->probe_error )
+                );
+        }
+
+        if ( count( $lines ) ) {
+            file_put_contents( $this->em_config->probe->history, implode( "\n", $lines ) . "\n", LOCK_EX | FILE_APPEND );
+        }
+
+        $this->debug_echo( "probe_sample: recorded " . count( $lines ) . " samples" );
+
+        return true;
+    }
+
     ## held_for() - how long a slot has been held, from acquired_at
     function held_for( $ts ) {
         if ( !$ts || ( $s = time() - $ts ) < 0 ) {
@@ -436,9 +496,10 @@ class em_openstack {
     ## finalmodel.php runs one waxsis container per frame, so an instantaneous
     ## check reads idle in the gaps between frames
 
-    function probe_instance( $ip, &$load, &$waxsis ) {
+    function probe_instance( $ip, &$load, &$waxsis, &$cores = null ) {
         $load   = "?";
         $waxsis = "?";
+        $cores  = "?";
 
         if ( !$this->appconfig_loaded ) {
             $this->load_appconfig();
@@ -454,7 +515,10 @@ class em_openstack {
         $probe_timeout         = 6;
         $probe_connect_timeout = 4;
 
-        $remote = 'echo L $(cut -d" " -f3 /proc/loadavg); if docker ps >/dev/null 2>&1; then echo W $(docker ps | grep -ci waxsis); else echo W ?; fi';
+        ## nproc so the reading can be a fraction of the machine rather than a
+        ## bare number: a flavor change must not silently invalidate it
+
+        $remote = 'echo L $(cut -d" " -f3 /proc/loadavg); echo C $(nproc); if docker ps >/dev/null 2>&1; then echo W $(docker ps | grep -ci waxsis); else echo W ?; fi';
 
         ## UserKnownHostsFile=/dev/null is not optional here. shelve and unshelve
         ## recycle addresses, so the same ip legitimately belongs to a different
@@ -487,6 +551,8 @@ class em_openstack {
         foreach ( $out as $line ) {
             if ( preg_match( '/^L\s+(\S+)/', $line, $m ) ) {
                 $load = $m[ 1 ];
+            } else if ( preg_match( '/^C\s+(\d+)/', $line, $m ) ) {
+                $cores = $m[ 1 ];
             } else if ( preg_match( '/^W\s+(\S+)/', $line, $m ) ) {
                 $waxsis = $m[ 1 ] == "?" ? "?" : ( intval( $m[ 1 ] ) > 0 ? "yes" : "no" );
             } else if ( strlen( trim( $line ) ) ) {
@@ -551,6 +617,8 @@ class em_openstack {
                 ,"held"   => $this->held_for( isset( $v->acquired_at ) ? $v->acquired_at : 0 )
                 ,"load"   => "-"
                 ,"waxsis" => "-"
+                ,"cores"  => "-"
+                ,"pct"    => "-"
                 ];
 
             switch( $v->status ) {
@@ -629,26 +697,29 @@ class em_openstack {
                     continue;
                 }
 
-                if ( !$this->probe_instance( $v->ip, $load, $waxsis ) && strlen( $this->probe_error ) ) {
+                if ( !$this->probe_instance( $v->ip, $load, $waxsis, $cores ) && strlen( $this->probe_error ) ) {
                     $probe_errors[] = sprintf( "  slot %-4s %-15s %s", $k, $v->ip, $this->probe_error );
                 }
 
                 $v->load   = $load;
                 $v->waxsis = $waxsis;
+                $v->cores  = $cores;
+                $v->pct    = $this->load_pct( $load, $cores );
             }
         }
 
         $fmt = $probe
-             ? "%-4s %-15s %-17s %-6s %7s %-6s %-8s %s\n"
+             ? "%-4s %-15s %-17s %-6s %7s %-5s %5s %-6s %-8s %s\n"
              : "%-4s %-15s %-17s %-6s %-8s %s\n";
 
         $instance_table = $probe
-                        ? sprintf( $fmt, "slot", "ip", "status", "use", "load15", "waxsis", "held", "tag" )
+                        ? sprintf( $fmt, "slot", "ip", "status", "use", "load15", "cores", "%cpu", "waxsis", "held", "tag" )
                         : sprintf( $fmt, "slot", "ip", "status", "use", "held", "tag" );
 
         foreach ( $instances as $k => $v ) {
             $instance_table .= $probe
-                             ? sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->load, $v->waxsis, $v->held, $v->tag )
+                             ? sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->load, $v->cores
+                                        ,$v->pct == "-" || $v->pct == "?" ? $v->pct : $v->pct . "%", $v->waxsis, $v->held, $v->tag )
                              : sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->held, $v->tag );
         }
 
@@ -1132,8 +1203,20 @@ class em_openstack {
 
         $this->debug_echo( $this->status( true ) );
 
+        $last_probe = 0;
+
         while( 1 ) {
             $this->debug_echo( $this->status( true ) );
+
+            ## probing is one ssh per active instance, far too slow for every
+            ## service loop, so it runs on its own interval
+
+            if ( isset( $this->em_config->probe->interval )
+                 && time() - $last_probe >= $this->em_config->probe->interval ) {
+                $last_probe = time();
+                $this->probe_sample();
+            }
+
             sleep( $this->em_config->sleep->service_loop );
         }            
     }

--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -41,6 +41,9 @@ class em_openstack {
     private $global_putenv_done = false;
 
     private $run_cmd_last_error_code;
+
+    ## why the last probe_instance() failed, so --probe can say more than "?"
+    public $probe_error = "";
     
     function __construct( $debug = false, $configfile = "em_config.json" ) {
         $this->debug       = $debug;
@@ -453,7 +456,17 @@ class em_openstack {
 
         $remote = 'echo L $(cut -d" " -f3 /proc/loadavg); if docker ps >/dev/null 2>&1; then echo W $(docker ps | grep -ci waxsis); else echo W ?; fi';
 
-        $cmd = sprintf( "timeout %d ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=%d %s %s 2>/dev/null"
+        ## UserKnownHostsFile=/dev/null is not optional here. shelve and unshelve
+        ## recycle addresses, so the same ip legitimately belongs to a different
+        ## instance with a different host key over time; persisting keys would
+        ## eventually fail every probe against a recycled address.
+        ##
+        ## LogLevel=ERROR suppresses the "Permanently added ... to the list of
+        ## known hosts" line at the source. It used to be swallowed by sending
+        ## all of stderr to /dev/null, which threw away the real errors too, so
+        ## an unreachable instance reported "?" with no reason attached.
+
+        $cmd = sprintf( "timeout %d ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=%d %s %s 2>&1"
                         ,$probe_timeout
                         ,escapeshellarg( $p->sshidentity )
                         ,$probe_connect_timeout
@@ -467,18 +480,29 @@ class em_openstack {
         ## outcome here, not something to log as a command failure
 
         $out = [];
-        exec( $cmd, $out );
+        exec( $cmd, $out, $code );
+
+        $noise = [];
 
         foreach ( $out as $line ) {
             if ( preg_match( '/^L\s+(\S+)/', $line, $m ) ) {
                 $load = $m[ 1 ];
-            }
-            if ( preg_match( '/^W\s+(\S+)/', $line, $m ) ) {
+            } else if ( preg_match( '/^W\s+(\S+)/', $line, $m ) ) {
                 $waxsis = $m[ 1 ] == "?" ? "?" : ( intval( $m[ 1 ] ) > 0 ? "yes" : "no" );
+            } else if ( strlen( trim( $line ) ) ) {
+                $noise[] = trim( $line );
             }
         }
 
-        return $load != "?";
+        if ( $load == "?" ) {
+            $this->probe_error = count( $noise )
+                               ? implode( " | ", $noise )
+                               : ( $code == 124 ? "timed out after {$probe_timeout}s" : "no answer, ssh exit $code" );
+            return false;
+        }
+
+        $this->probe_error = "";
+        return true;
     }
 
     function status( $update = false, $probe = false ) {
@@ -597,12 +621,18 @@ class em_openstack {
         ## probing is one ssh per instance, so only on request and only where
         ## there is a running OS to answer
 
+        $probe_errors = [];
+
         if ( $probe ) {
             foreach ( $instances as $k => $v ) {
                 if ( $v->status != "ACTIVE" ) {
                     continue;
                 }
-                $this->probe_instance( $v->ip, $load, $waxsis );
+
+                if ( !$this->probe_instance( $v->ip, $load, $waxsis ) && strlen( $this->probe_error ) ) {
+                    $probe_errors[] = sprintf( "  slot %-4s %-15s %s", $k, $v->ip, $this->probe_error );
+                }
+
                 $v->load   = $load;
                 $v->waxsis = $waxsis;
             }
@@ -620,6 +650,10 @@ class em_openstack {
             $instance_table .= $probe
                              ? sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->load, $v->waxsis, $v->held, $v->tag )
                              : sprintf( $fmt, $k, $v->ip, $v->status, $v->use, $v->held, $v->tag );
+        }
+
+        if ( count( $probe_errors ) ) {
+            $instance_table .= "\nprobe failures:\n" . implode( "\n", $probe_errors ) . "\n";
         }
 
         if ( $update ) {


### PR DESCRIPTION
Makes the probe fit to run unattended. **No threshold and no alerting yet, deliberately** — this collects the data needed to choose one honestly.

## 1. The reading is now a fraction of the machine

The probe asks for `nproc` alongside the load average, so `--status --probe` reports `%cpu` rather than a bare number:

```
slot ip              status            use     load15 cores  %cpu waxsis held     tag
2    10.0.10.25      ACTIVE            in use   50.44 64      79% yes    2d 14h   saxsafold-dev:mattia:ce9b9f80
```

A raw `load15` means nothing without the core count, and the core count changes with the flavor. A `m3.2xl` at 50.44 and an 8 core instance at 6.10 are both ~78% of their machine; only the percentage says so. Anything built on top of this should key off `%cpu`, so a flavor change cannot silently invalidate it.

## 2. Every sample is recorded

The daemon probes every `probe.interval` seconds and appends one line per ACTIVE instance to `probe.history`:

```
2026-07-27 11:00:21 slot=2 cores=64 load15=50.44 pct=79 waxsis=yes use=inuse ip=10.0.10.25 tag=saxsafold-dev:mattia:ce9b9f80
2026-07-27 11:05:22 slot=2 cores=? load15=? pct=? waxsis=? use=inuse ip=10.0.10.25 tag=... error=ssh:_connect_..._refused
```

Separate file so the manager log stays readable, `key=value` so it is greppable and easy to parse later.

Recording *every* sample, not just interesting ones, is the point. We know what a working job looks like from one observation and nothing about the gaps between frames — and load15 is a 15 minute EMA, so a healthy job that pauses ~10 minutes decays from 50 to ~26 and would trip a 50% rule on a single reading. Which gaps are normal is exactly what these samples will show. Picking a threshold before that is guesswork, and the hold time distribution already taught us how badly guesses do here.

New config, both optional — absent `probe.history` disables sampling entirely:

```json
,"probe" : {
    "interval"  : 300
    ,"history"  : "em_probe.log"
}
```

`em_install.php` treats `probe.history` as a runtime file, so a committed `em_probe.log` can never be installed over a live one.

## 3. A failed probe now says why

`--probe` silenced ssh's "Permanently added ... to the list of known hosts" line by sending **all** of stderr to `/dev/null`, discarding real errors with it. An unreachable instance reported a bare `?`.

`-o LogLevel=ERROR` suppresses that warning at the source so stderr can be kept:

```
probe failures:
  slot 1    10.0.10.78      ssh: connect to host 10.0.10.78 port 22: Connection refused
```

A timeout with no output reports `timed out after 6s`, since `timeout` exits 124. Reasons are recorded in the history too.

`UserKnownHostsFile=/dev/null` was already there and stays, now with a comment explaining why it is load bearing rather than incidental: **shelve and unshelve recycle addresses**, so the same ip legitimately belongs to a different instance with a different host key over time. Persisting keys would eventually fail every probe against a recycled address, and it would look like a security warning rather than a stale entry. I audited the other three ssh call sites in the manager — `postssh` in `unshelve()` and `launch_one()`, and the `/tmp/ready` check — all already pass it.

## Testing

With a fake `ssh` on PATH:

- 64 core instance at load 50.44 reports 79%; an 8 core instance at 6.10 reports 76%, confirming the normalisation
- `probe_sample()` writes one line per ACTIVE instance, fields parse to a consistent key set
- unreachable instance: `?` in the table, reason listed under it, reason recorded in the history
- shelved instances are not probed
- `php -l` clean on 7.4 and 8.2, `em_config.json` still valid json

## Restart impact

**Requires a daemon restart.** `em_config.json` is `config` scope, and the sampling loop lives in `server_start()`, so neither takes effect until then. The `--status --probe` changes are client side and live immediately.

```
php em_install.php --fetch --install --restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
