### PR TITLE
elasticmanager: --restart mistook a zombie for a running daemon

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_install.php
+++ b/languages/html5/openstack/elasticmanager/em_install.php
@@ -240,6 +240,28 @@ function startup_count() {
     return count( preg_grep( '/ - STARTUP/', file( $f ) ) );
 }
 
+## pid_alive() - is this pid a live process?
+##
+## /proc/<pid> existing is not enough. a dead process keeps its /proc entry
+## until it is reaped, and pid 1 in this container is "sleep infinity", which
+## never reaps anything, so an orphaned daemon becomes a zombie that lingers
+## forever. checking only for the directory made --restart report "did not stop
+## within 20s" for a daemon it had already killed, and refuse to start a
+## replacement, leaving the pool with no manager at all. zombies have an empty
+## cmdline, which is how they are told apart.
+
+function pid_alive( $pid ) {
+    clearstatcache();
+
+    if ( !is_dir( "/proc/$pid" ) ) {
+        return false;
+    }
+
+    $cl = @file_get_contents( "/proc/$pid/cmdline" );
+
+    return $cl !== false && strlen( str_replace( "\0", "", $cl ) ) > 0;
+}
+
 ## service_pid() - the daemon holds its lock as a symlink to /proc/<pid>.
 ## em_service.php takes lockdir from appconfig first and only falls back to
 ## em_config, so check both, and fall back to the process list because the lock
@@ -272,7 +294,7 @@ function service_pid() {
         if ( is_link( $lock )
              && ( $link = readlink( $lock ) ) !== false
              && preg_match( '#/proc/(\d+)#', $link, $m )
-             && is_dir( "/proc/" . $m[ 1 ] ) ) {
+             && pid_alive( $m[ 1 ] ) ) {
             return $m[ 1 ];
         }
     }
@@ -323,9 +345,7 @@ function daemon_restart() {
         $gone = false;
 
         for ( $i = 0; $i < 20; ++$i ) {
-            clearstatcache();
-
-            if ( !is_dir( "/proc/$pid" ) ) {
+            if ( !pid_alive( $pid ) ) {
                 $gone = true;
                 break;
             }


### PR DESCRIPTION
## What happened

```
php em_install.php --restart
pool: 1 in use [2], 0 mid operation []

stopping daemon pid 8444
ERROR: daemon pid 8444 did not stop within 20s, not starting a second one
```

The daemon had in fact stopped instantly. The tool then refused to start a replacement, **leaving the pool with no manager at all** until it was started by hand. That is the worst possible outcome for a safety check: it fired on a healthy operation and its refusal caused the outage it was meant to prevent.

```
$ ps -fp 8444
UID          PID    PPID  C STIME TTY          TIME CMD
jobrunn+    8444       1  0 07:17 pts/2    00:00:00 [php] <defunct>
```

## Why

`daemon_restart()` waited for `is_dir( "/proc/$pid" )` to go away. A dead process keeps its `/proc` entry until it is reaped, and **pid 1 in this container is `sleep infinity`**, which never reaps anything. `em_start.sh` backgrounds the daemon with `nohup` and exits, so the daemon is orphaned to pid 1 the moment it starts. When it dies it becomes a zombie that lingers indefinitely, `/proc/<pid>` and all.

So in this container, "the `/proc` entry is gone" is not a usable liveness test, and never will be.

This is also why the manual check worked while the tool's did not: `pgrep -f` matches on the command line, and a zombie's cmdline is empty, so pgrep correctly reported the daemon stopped.

## Fix

A `pid_alive()` helper that treats a zombie as dead, used both in the restart wait and when validating the pid from the lock symlink:

```php
function pid_alive( $pid ) {
    clearstatcache();

    if ( !is_dir( "/proc/$pid" ) ) {
        return false;
    }

    $cl = @file_get_contents( "/proc/$pid/cmdline" );

    return $cl !== false && strlen( str_replace( "\0", "", $cl ) ) > 0;
}
```

`em_service.php`'s own `tryLock()` already survives this, because it compares the cmdline against an expected value and an empty one does not match — so a stale lock pointing at a zombie is correctly treated as stale. `em_install.php` was the only place trusting the directory alone.

## Testing

Against a real zombie, created by forking a child that exits under a parent that never waits:

```
live pid 2091            : alive
absent pid 999999        : dead
zombie pid 2092 state Z  : /proc exists=YES  state=Z  pid_alive=dead (correct)
```

The earlier `--restart` tests passed only because the stub daemon was a direct child of the test shell, which reaped it. The production container has no reaper, which is exactly the case the tests missed.

`php -l` clean on 7.4 and 8.2.

## Restart impact

`em_install.php` is `standalone`. Nothing to restart, and as always the running copy is already compiled, so the fix applies from the next invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
