### PR TITLE
elasticmanager: warn when a held instance stops doing work

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_config.json
+++ b/languages/html5/openstack/elasticmanager/em_config.json
@@ -15,8 +15,10 @@
         ,"acquire_wait" : 15
     }
     ,"probe" : {
-        "interval"  : 300
-        ,"history"  : "em_probe.log"
+        "interval"     : 300
+        ,"history"     : "em_probe.log"
+        ,"min_pct"     : 50
+        ,"consecutive" : 3
     }
     ,"flavors" : {
         "m3.2xl" : {

--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -44,6 +44,11 @@ class em_openstack {
 
     ## why the last probe_instance() failed, so --probe can say more than "?"
     public $probe_error = "";
+
+    ## consecutive low cpu readings per slot, and whether this episode has
+    ## already been warned about. process local on purpose, see probe_check()
+    private $probe_low     = [];
+    private $probe_alerted = [];
     
     function __construct( $debug = false, $configfile = "em_config.json" ) {
         $this->debug       = $debug;
@@ -441,7 +446,8 @@ class em_openstack {
     ## idle gap actually look like over time.
 
     function probe_sample() {
-        if ( !isset( $this->em_config->probe->history ) ) {
+        if ( !isset( $this->em_config->probe->history )
+             && !isset( $this->em_config->probe->min_pct ) ) {
             return false;
         }
 
@@ -458,14 +464,17 @@ class em_openstack {
                 continue;
             }
 
-            $ok = $this->probe_instance( $v->network, $load, $waxsis, $cores );
+            $ok  = $this->probe_instance( $v->network, $load, $waxsis, $cores );
+            $pct = $this->load_pct( $load, $cores );
+
+            $this->probe_check( $k, $v, $pct );
 
             $lines[] = sprintf( "%s slot=%s cores=%s load15=%s pct=%s waxsis=%s use=%s ip=%s tag=%s%s"
                                 ,$this->timestamp()
                                 ,$k
                                 ,$cores
                                 ,$load
-                                ,$this->load_pct( $load, $cores )
+                                ,$pct
                                 ,$waxsis
                                 ,( isset( $v->use_status ) && $v->use_status == "in use" ) ? "inuse" : "idle"
                                 ,$v->network
@@ -474,13 +483,74 @@ class em_openstack {
                 );
         }
 
-        if ( count( $lines ) ) {
+        if ( count( $lines ) && isset( $this->em_config->probe->history ) ) {
             file_put_contents( $this->em_config->probe->history, implode( "\n", $lines ) . "\n", LOCK_EX | FILE_APPEND );
         }
 
         $this->debug_echo( "probe_sample: recorded " . count( $lines ) . " samples" );
 
         return true;
+    }
+
+    ## probe_check() - warn once when a held slot stays under probe:min_pct for
+    ## probe:consecutive readings in a row.
+    ##
+    ## only held slots: an idle instance is legitimately near nothing, and the
+    ## floor is not zero anyway, a kworker stuck in D state since boot puts it
+    ## around 2% of a 64 core box.
+    ##
+    ## consecutive readings matter because load15 is a 15 minute average that
+    ## decays: a working job that pauses between waxsis frames slides down for
+    ## a while before recovering, and a single low reading proves nothing. an
+    ## unreadable probe is not counted either way, it is a different failure and
+    ## is already recorded with its reason in the history.
+    ##
+    ## the counters live in this process, so a daemon restart just delays an
+    ## alert rather than losing correctness.
+
+    function probe_check( $slot, $v, $pct ) {
+        if ( !isset( $this->em_config->probe->min_pct ) ) {
+            return;
+        }
+
+        if ( !isset( $v->use_status ) || $v->use_status != "in use" || !is_numeric( $pct ) ) {
+            return;
+        }
+
+        $min  = $this->em_config->probe->min_pct;
+        $need = isset( $this->em_config->probe->consecutive ) ? $this->em_config->probe->consecutive : 3;
+
+        if ( $pct >= $min ) {
+            if ( !empty( $this->probe_alerted[ $slot ] ) ) {
+                $this->log( sprintf( "probe: slot %s back above %d%% cpu (%d%%)", $slot, $min, $pct ) );
+            }
+
+            $this->probe_low[ $slot ]     = 0;
+            $this->probe_alerted[ $slot ] = false;
+            return;
+        }
+
+        $this->probe_low[ $slot ] = ( isset( $this->probe_low[ $slot ] ) ? $this->probe_low[ $slot ] : 0 ) + 1;
+
+        $this->debug_echo( sprintf( "probe_check: slot %s at %d%%, %d of %d low readings", $slot, $pct, $this->probe_low[ $slot ], $need ) );
+
+        if ( $this->probe_low[ $slot ] < $need || !empty( $this->probe_alerted[ $slot ] ) ) {
+            return;
+        }
+
+        ## one alert per episode, not one every interval until it recovers
+
+        $this->probe_alerted[ $slot ] = true;
+
+        $this->echo_warn( sprintf( "slot %s looks idle: %d%% cpu, under %d%% for %d consecutive probes %ds apart. held %s by %s, ip %s"
+                                   ,$slot
+                                   ,$pct
+                                   ,$min
+                                   ,$this->probe_low[ $slot ]
+                                   ,isset( $this->em_config->probe->interval ) ? $this->em_config->probe->interval : 0
+                                   ,$this->held_for( isset( $v->acquired_at ) ? $v->acquired_at : 0 )
+                                   ,empty( $v->use_id ) ? "unknown" : $v->use_id
+                                   ,isset( $v->network ) ? $v->network : "?" ) );
     }
 
     ## held_for() - how long a slot has been held, from acquired_at


### PR DESCRIPTION
Builds on the sampling from #60. A held slot that stays under `probe:min_pct` for `probe:consecutive` readings in a row now raises one warning, which the existing `log()` path emails to `notify`.

```json
,"probe" : {
    "interval"     : 300
    ,"history"     : "em_probe.log"
    ,"min_pct"     : 50
    ,"consecutive" : 3
}
```

Omit `min_pct` and it goes back to sampling only, so it stays opt in.

```
WARNING: slot 2 looks idle: 23% cpu, under 50% for 3 consecutive probes 300s apart.
         held 1d 21h by saxsafold-dev:mattia:ce9b9f80, ip 10.0.10.25
```

The message carries the slot, the reading, the threshold it missed, how long the slot has been held and by whom, so the mail is actionable without going to the box.

## The three decisions worth reviewing

**Only held slots are checked.** An idle instance is legitimately near nothing, and the floor is not zero anyway — a kworker wedged in D state since boot puts it around 2% of a 64 core box.

**Consecutive readings, because `load15` is a decaying 15 minute average.** A working job that pauses between waxsis frames slides down for a while before recovering, so a single low reading proves nothing. Three at 300s covers a 15 minute window, matching the averaging period.

**One alert per episode, not one per interval.** A slot stuck low for a day would otherwise mail every 5 minutes. It re-arms when the slot recovers, and the recovery is logged but deliberately not mailed.

An unreadable probe is not counted either way. That is a different failure, already recorded with its reason in the history by #60, and counting it here would conflate "the job stopped working" with "I could not reach the box".

The counters live in the daemon process, so a restart just delays an alert rather than losing correctness.

## Testing

Driving one long lived object through a scripted sequence of readings, so the counters persist across samples exactly as they do in the daemon:

| sequence | expected | result |
|---|---|---|
| 89, 88, 31, 28, 23, 19, 86, 84 | warn once at the third low, log recovery | 1 warning at 23%, 1 email, `probe: slot 2 back above 50% cpu (86%)` |
| 89, 31, 88, 28, 89, 23, 88 | nothing, a lone dip resets the counter | 0 warnings, 0 emails |
| ten consecutive low readings | one alert, not ten | 1 warning, 1 email |

The idle slot never appears in any warning. `php -l` clean on 7.4 and 8.2, `em_config.json` still valid json.

## Before this is any use

**Confirm mail actually delivers.** `log()` has called `mymail()` roughly 523 times already (509 warnings, 14 startups) and we have no evidence any of it arrived:

```
php em_test_mail.php emre.brookes@umt.edu
```

If that does not land, this feature is a smoke detector with no battery.

## Threshold caveat

50% is chosen from four observations of one continuously busy job (79, 86, 89, 90%) and **zero observations of a between frame gap**. The gaps are exactly what could false positive. `em_probe.log` is accumulating the real distribution now, and the numbers are config so they can be tuned without a code change:

```
awk '/use=inuse/ && /waxsis=no/ {for(i=1;i<=NF;i++) if($i ~ /^pct=/) print substr($i,5)}' em_probe.log | sort -n | uniq -c
```

Warn only, so a wrong threshold costs an email rather than a job.

## Restart impact

**Requires a daemon restart.** `em_config.json` is `config` scope and the check runs inside `probe_sample()` from the service loop.

```
php em_install.php --fetch --install --restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
