### PR TITLE
elasticmanager: a notification that fails to send should say so

### DIFF
--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -1264,6 +1264,10 @@ class em_openstack {
         $this->debug_echo( "em_openstack: server_start()" );
         $this->log( "STARTUP : elastic manager server id $this->id flavor $this->flavor" );
 
+        if ( !$this->mail_transport_ok( $why ) ) {
+            $this->echo_warn( "mail transport looks down, $why. notifications will not be delivered until it is started" );
+        }
+
         ## read current server state & config & determine what's needed
         $this->read_config();
         
@@ -1374,6 +1378,40 @@ class em_openstack {
         }
     }
 
+    ## mail_transport_ok() - can a notification actually leave the box?
+    ##
+    ## postfix in this container does not restart on its own after a docker
+    ## start, which is what happens after a jetstream maintenance reboot. an
+    ## alert raised in that window would be silently undeliverable, so say so
+    ## at startup where it will be seen.
+
+    function mail_transport_ok( &$why ) {
+        $why  = "";
+        $host = "127.0.0.1";
+        $port = 25;
+
+        if ( isset( $this->em_config->files->appconfig ) && file_exists( $this->em_config->files->appconfig ) ) {
+            $app = json_decode( file_get_contents( $this->em_config->files->appconfig ) );
+
+            if ( isset( $app->mail->smtp->host ) ) {
+                $host = $app->mail->smtp->host;
+                $port = isset( $app->mail->smtp->port ) && $app->mail->smtp->port ? $app->mail->smtp->port : 25;
+            }
+        }
+
+        ob_start();
+        $fp = @fsockopen( $host, $port, $errno, $errstr, 5 );
+        ob_end_clean();
+
+        if ( $fp ) {
+            fclose( $fp );
+            return true;
+        }
+
+        $why = "cannot connect to $host:$port ($errstr)";
+        return false;
+    }
+
     ## --- logfile functions ----
     function timestamp() {
         $date = new DateTimeImmutable();
@@ -1399,7 +1437,16 @@ class em_openstack {
                 $tag .= "shutdown";
             }
             $host = gethostname();
-            mymail( $this->notify, "[$host][$this->id] $tag", $msg );
+
+            ## mymail() returns true on failure. write the failure straight to
+            ## the file rather than calling log(), which would try to mail
+            ## about the mail failing
+
+            if ( mymail( $this->notify, "[$host][$this->id] $tag", $msg ) ) {
+                file_put_contents( $this->logfile
+                                   ,$this->timestamp() . " - NOTIFY FAILED : could not mail $this->notify, the message above was not delivered\n"
+                                   ,LOCK_EX | FILE_APPEND );
+            }
         }
     }
 

--- a/languages/html5/openstack/elasticmanager/em_openstack.php
+++ b/languages/html5/openstack/elasticmanager/em_openstack.php
@@ -1265,7 +1265,7 @@ class em_openstack {
         $this->log( "STARTUP : elastic manager server id $this->id flavor $this->flavor" );
 
         if ( !$this->mail_transport_ok( $why ) ) {
-            $this->echo_warn( "mail transport looks down, $why. notifications will not be delivered until it is started" );
+            $this->echo_warn( "configured smtp server unreachable, $why. notifications will be lost until it is reachable" );
         }
 
         ## read current server state & config & determine what's needed
@@ -1378,26 +1378,30 @@ class em_openstack {
         }
     }
 
-    ## mail_transport_ok() - can a notification actually leave the box?
+    ## mail_transport_ok() - only meaningful when we open the connection ourselves.
     ##
-    ## postfix in this container does not restart on its own after a docker
-    ## start, which is what happens after a jetstream maintenance reboot. an
-    ## alert raised in that window would be silently undeliverable, so say so
-    ## at startup where it will be seen.
+    ## with mail:smtp set, phpmailer connects to that server at send time and a
+    ## failure loses the message. without it we hand off to the local sendmail,
+    ## which accepts into postfix's maildrop whether or not postfix is running
+    ## and delivers once it starts, so a stopped postfix delays notifications
+    ## rather than losing them. there is nothing to check in that case, and
+    ## postfix's health is not this program's business.
 
     function mail_transport_ok( &$why ) {
-        $why  = "";
-        $host = "127.0.0.1";
-        $port = 25;
+        $why = "";
 
-        if ( isset( $this->em_config->files->appconfig ) && file_exists( $this->em_config->files->appconfig ) ) {
-            $app = json_decode( file_get_contents( $this->em_config->files->appconfig ) );
-
-            if ( isset( $app->mail->smtp->host ) ) {
-                $host = $app->mail->smtp->host;
-                $port = isset( $app->mail->smtp->port ) && $app->mail->smtp->port ? $app->mail->smtp->port : 25;
-            }
+        if ( !isset( $this->em_config->files->appconfig ) || !file_exists( $this->em_config->files->appconfig ) ) {
+            return true;
         }
+
+        $app = json_decode( file_get_contents( $this->em_config->files->appconfig ) );
+
+        if ( !isset( $app->mail->smtp->host ) ) {
+            return true;
+        }
+
+        $host = $app->mail->smtp->host;
+        $port = isset( $app->mail->smtp->port ) && $app->mail->smtp->port ? $app->mail->smtp->port : 25;
 
         ob_start();
         $fp = @fsockopen( $host, $port, $errno, $errstr, 5 );


### PR DESCRIPTION
## Why

`mymail()` returns **true on failure**, and `log()` discarded the return entirely. A notification that failed to send left no record anywhere — not in the log, not on stdout. The only evidence would be an email that never arrived, which is not evidence anyone can notice.

## What this does not claim to fix

My first version of this was wrong and is worth writing down so it is not re-attempted.

A stopped postfix does **not** lose notifications. The sendmail path hands the message to `postdrop`, which accepts it into `maildrop` whether or not the postfix daemons are running, and delivers once they start. So `mymail()` succeeds, nothing has failed, and the queued messages arrive as soon as `postfix start` runs. Delay, not loss.

That also means checking a local port 25 is meaningless on that path: it would have warned "notifications will not be delivered" at every startup while postfix was stopped, about messages sitting safely in a queue. Monitoring postfix's health is not this program's business either.

## Two changes, narrowed to what is actually true

**A failed notification is recorded.** Written straight to the log file rather than through `log()`, which would otherwise try to mail about the mail failing:

```
WARNING: slot 2 looks idle: 23% cpu, under 50% for 3 consecutive probes ...
NOTIFY FAILED : could not mail emre.brookes@umt.edu, the message above was not delivered
```

On the sendmail path this never fires, because nothing fails. It exists for the case where something genuinely does.

**The startup transport check only runs when `mail:smtp` is configured.** That is the only path where this program opens the connection itself and a failure loses the message:

```
WARNING: configured smtp server unreachable, cannot connect to smtp.example.org:587 (Connection refused).
         notifications will be lost until it is reachable
```

With no `mail:smtp`, the check returns true immediately and says nothing.

## Testing

- sendmail path, postfix stopped: `mail transport ok: yes`, no warning, alert logged normally — the production configuration
- `mail:smtp` pointing at an unreachable port: warns with the reason
- mail failing at the PEAR layer: `NOTIFY FAILED` recorded after the warning
- mail working: no `NOTIFY FAILED`
- `php -l` clean on 7.4 and 8.2

## Restart impact

**Requires a daemon restart** for the startup check. The `NOTIFY FAILED` recording lives in `log()`, so it is hot for `em_client.php` immediately and applies to the daemon on its next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
